### PR TITLE
Add abillity for ui to be served from a subpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:10 as ui
 ARG API_ENDPOINT
 ENV API_ENDPOINT=${API_ENDPOINT}
 
+ARG UI_PUBLIC_URL
+ENV UI_PUBLIC_URL=${UI_PUBLIC_URL}
+
 RUN mkdir -p /app
 WORKDIR /app
 
@@ -11,7 +14,7 @@ COPY ui/package*.json /app/
 RUN npm install
 COPY ui /app
 
-RUN npm run build
+RUN npm run build -- --public-url $UI_PUBLIC_URL
 
 # Build API
 FROM golang:alpine AS api

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,7 +16,7 @@ services:
     build:
       context: "."
       args:
-        - UI_PUBLIC_URL=/test/
+        - UI_PUBLIC_URL=/
 
         # Change This: The url from which the web ui can access the backend
         # Should by default be the value of PUBLIC_ENDPOINT with /api appended to it

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,6 +16,10 @@ services:
     build:
       context: "."
       args:
+        - UI_PUBLIC_URL=/test/
+
+        # Change This: The url from which the web ui can access the backend
+        # Should by default be the value of PUBLIC_ENDPOINT with /api appended to it
         - API_ENDPOINT=http://localhost:8000/api/
 
     restart: always
@@ -31,7 +35,7 @@ services:
       - PHOTO_CACHE=/app/cache
       - SERVE_UI=1
 
-      # Change This: The publicly exposed url for the api
+      # Change This: The publicly exposed url
       # For example if the server is available from the domain example.com,
       # change this value to http://example.com/
       - PUBLIC_ENDPOINT=http://localhost:8000/


### PR DESCRIPTION
This closes #20 

@simhnna can you try to setup this branch with your reverse proxy and see if you can get it to work under a subpath?

You should be able to set `UI_PUBLIC_URL` in the new `docker-compose.yml` to the subpath the ui is served from.

You will need to rebuild the container each time `UI_PUBLIC_URL` has been changed

    $ docker-compose up --build