### PR TITLE
Define max key length of 11 in mysql migrations

### DIFF
--- a/api/database/migrations/001_user.up.sql
+++ b/api/database/migrations/001_user.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS user (
-  user_id int NOT NULL AUTO_INCREMENT,
+  user_id int(11) NOT NULL AUTO_INCREMENT,
   username varchar(256) NOT NULL UNIQUE,
   password varchar(256),
   root_path varchar(512),
@@ -9,8 +9,8 @@ CREATE TABLE IF NOT EXISTS user (
 );
 
 CREATE TABLE IF NOT EXISTS access_token (
-	token_id int NOT NULL AUTO_INCREMENT,
-  user_id int NOT NULL,
+	token_id int(11) NOT NULL AUTO_INCREMENT,
+  user_id int(11) NOT NULL,
 	value char(24) NOT NULL UNIQUE,
 	expire timestamp NOT NULL,
 

--- a/api/database/migrations/002_photo.up.sql
+++ b/api/database/migrations/002_photo.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS photo_exif (
-  exif_id int NOT NULL AUTO_INCREMENT,
+  exif_id int(11) NOT NULL AUTO_INCREMENT,
   camera varchar(256),
   maker varchar(256),
   lens varchar(256),
@@ -16,10 +16,10 @@ CREATE TABLE IF NOT EXISTS photo_exif (
 );
 
 CREATE TABLE IF NOT EXISTS album (
-  album_id int NOT NULL AUTO_INCREMENT,
+  album_id int(11) NOT NULL AUTO_INCREMENT,
   title varchar(256) NOT NULL,
-  parent_album int,
-  owner_id int NOT NULL,
+  parent_album int(11),
+  owner_id int(11) NOT NULL,
   path varchar(512) NOT NULL UNIQUE,
 
   PRIMARY KEY (album_id),
@@ -28,11 +28,11 @@ CREATE TABLE IF NOT EXISTS album (
 );
 
 CREATE TABLE IF NOT EXISTS photo (
-  photo_id int NOT NULL AUTO_INCREMENT,
+  photo_id int(11) NOT NULL AUTO_INCREMENT,
   title varchar(256) NOT NULL,
   path varchar(1024) NOT NULL UNIQUE,
-  album_id int NOT NULL,
-  exif_id int,
+  album_id int(11) NOT NULL,
+  exif_id int(11),
 
   PRIMARY KEY (photo_id),
   FOREIGN KEY (album_id) REFERENCES album(album_id) ON DELETE CASCADE,
@@ -40,11 +40,11 @@ CREATE TABLE IF NOT EXISTS photo (
 );
 
 CREATE TABLE IF NOT EXISTS photo_url (
-  url_id int NOT NULL AUTO_INCREMENT,
-  photo_id int NOT NULL,
+  url_id int(11) NOT NULL AUTO_INCREMENT,
+  photo_id int(11) NOT NULL,
   photo_name varchar(512) NOT NULL,
-  width int NOT NULL,
-  height int NOT NULL,
+  width int(11) NOT NULL,
+  height int(11) NOT NULL,
   purpose varchar(64) NOT NULL,
   content_type varchar(64) NOT NULL,
 

--- a/api/database/migrations/004_shares.up.sql
+++ b/api/database/migrations/004_shares.up.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS share_token (
-  token_id int AUTO_INCREMENT,
+  token_id int(11) AUTO_INCREMENT,
   value char(24) NOT NULL UNIQUE,
-  owner_id int NOT NULL,
+  owner_id int(11) NOT NULL,
   expire timestamp NULL DEFAULT NULL,
   password varchar(256),
-  album_id int,
-  photo_id int,
+  album_id int(11),
+  photo_id int(11),
 
   PRIMARY KEY (token_id)
   -- CHECK (album_id IS NOT NULL OR photo_id IS NOT NULL)


### PR DESCRIPTION
This closes #23 

@BkSouX I've updated the database migrations to explicitly set a max length for all keys in the database.

Would you please try to install this branch on your ARM setup to test if this solves your issue?

Note that you will have to wipe the database and let the migration set it up again