### PR TITLE
fix default port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ cd photoview
 $ docker-compose up -d
 ```
 
-If the endpoint or the port hasn't been changed in the `docker-compose.yml` file, PhotoView can now be accessed at http://localhost:8080
+If the endpoint or the port hasn't been changed in the `docker-compose.yml` file, PhotoView can now be accessed at http://localhost:8000
 
 ### Initial Setup
 


### PR DESCRIPTION
docker-compose has port 8000, but README had 8080. Setting README to 8000, so it match docker-compose