### PR TITLE
Move sidebar to the bottom on mobile

### DIFF
--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -28,6 +28,17 @@ const SideMenu = styled.div`
   width: 80px;
   left: 0;
   padding-top: 70px;
+
+  @media (max-width: 1000px) {
+    width: 100%;
+    height: 80px;
+    position: fixed;
+    background: white;
+    z-index: 10;
+    padding-top: 0;
+    display: flex;
+    bottom: 0;
+  }
 `
 
 const Content = styled.div`

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -38,6 +38,7 @@ const SideMenu = styled.div`
     padding-top: 0;
     display: flex;
     bottom: 0;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
   }
 `
 

--- a/ui/src/components/header/Header.js
+++ b/ui/src/components/header/Header.js
@@ -21,6 +21,15 @@ const Title = styled.h1`
   font-weight: 400;
   padding: 2px 12px;
   flex-grow: 1;
+  min-width: 245px;
+
+  @media (max-width: 400px) {
+    min-width: auto;
+
+    & span {
+      display: none;
+    }
+  }
 `
 
 const Logo = styled.img`

--- a/ui/src/components/photoGallery/PhotoGallery.js
+++ b/ui/src/components/photoGallery/PhotoGallery.js
@@ -14,6 +14,11 @@ const Gallery = styled.div`
   min-height: 200px;
   position: relative;
   margin: -4px;
+
+  @media (max-width: 1000px) {
+    /* Compensate for tab bar on mobile */
+    margin-bottom: 76px;
+  }
 `
 
 const PhotoFiller = styled.div`

--- a/ui/src/components/sidebar/Sidebar.js
+++ b/ui/src/components/sidebar/Sidebar.js
@@ -1,6 +1,7 @@
 import React, { createContext } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { Icon } from 'semantic-ui-react'
 
 const SidebarContainer = styled.div`
   width: 28vw;
@@ -19,8 +20,21 @@ const SidebarContainer = styled.div`
     width: 100%;
     /* full height - header - tabbar */
     height: calc(100% - 60px - 80px);
-    max-width: calc(100vw - 85px);
-    transform: translateX(100vw);
+    max-width: min(calc(100vw - 85px), 400px);
+    ${({ highlighted }) => `transform: translateX(${highlighted ? 0 : 100}vw);`}
+    padding-top: 45px;
+  }
+
+  transition: transform 200ms ease-in-out;
+`
+
+const SidebarDismissButton = styled(Icon)`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+
+  @media (min-width: 700px) {
+    display: none;
   }
 `
 
@@ -48,8 +62,14 @@ class Sidebar extends React.Component {
         {this.props.children}
         <SidebarContext.Consumer>
           {value => (
-            <SidebarContainer>
+            <SidebarContainer highlighted={value.content != null}>
               {value.content}
+              <SidebarDismissButton
+                name="angle double right"
+                size="big"
+                link
+                onClick={() => this.setState({ content: null })}
+              />
               <div style={{ height: 100 }}></div>
             </SidebarContainer>
           )}

--- a/ui/src/components/sidebar/Sidebar.js
+++ b/ui/src/components/sidebar/Sidebar.js
@@ -17,6 +17,8 @@ const SidebarContainer = styled.div`
   @media (max-width: 700px) {
     position: absolute;
     width: 100%;
+    /* full height - header - tabbar */
+    height: calc(100% - 60px - 80px);
     max-width: calc(100vw - 85px);
     transform: translateX(100vw);
   }


### PR DESCRIPTION
Related to #7

- Move sidebar to the bottom
- Hide photoview header text on smaller screens
- Make the sidebar show up when photo is pressed, and added a button to hide it again
- Fix various layout problems on mobile

![Screen Shot 2020-08-17 at 13 52 58](https://user-images.githubusercontent.com/4233458/90393668-82596d80-e091-11ea-9ffa-5445519f2632.png)


