### PR TITLE
Fixes viktorstrate/photoview#6 : Added "Show favorites" toggle to view the favorited media

### DIFF
--- a/api/graphql/generated.go
+++ b/api/graphql/generated.go
@@ -54,7 +54,7 @@ type ComplexityRoot struct {
 	Album struct {
 		FilePath    func(childComplexity int) int
 		ID          func(childComplexity int) int
-		Media       func(childComplexity int, filter *models.Filter) int
+		Media       func(childComplexity int, filter *models.Filter, onlyFavorites *bool) int
 		Owner       func(childComplexity int) int
 		ParentAlbum func(childComplexity int) int
 		Path        func(childComplexity int) int
@@ -144,7 +144,7 @@ type ComplexityRoot struct {
 	Query struct {
 		Album                      func(childComplexity int, id int) int
 		Media                      func(childComplexity int, id int) int
-		MyAlbums                   func(childComplexity int, filter *models.Filter, onlyRoot *bool, showEmpty *bool) int
+		MyAlbums                   func(childComplexity int, filter *models.Filter, onlyRoot *bool, showEmpty *bool, onlyWithFavorites *bool) int
 		MyMedia                    func(childComplexity int, filter *models.Filter) int
 		MyUser                     func(childComplexity int) int
 		Search                     func(childComplexity int, query string, limitMedia *int, limitAlbums *int) int
@@ -207,7 +207,7 @@ type ComplexityRoot struct {
 }
 
 type AlbumResolver interface {
-	Media(ctx context.Context, obj *models.Album, filter *models.Filter) ([]*models.Media, error)
+	Media(ctx context.Context, obj *models.Album, filter *models.Filter, onlyFavorites *bool) ([]*models.Media, error)
 	SubAlbums(ctx context.Context, obj *models.Album, filter *models.Filter) ([]*models.Album, error)
 	ParentAlbum(ctx context.Context, obj *models.Album) (*models.Album, error)
 	Owner(ctx context.Context, obj *models.Album) (*models.User, error)
@@ -246,7 +246,7 @@ type QueryResolver interface {
 	SiteInfo(ctx context.Context) (*models.SiteInfo, error)
 	User(ctx context.Context, filter *models.Filter) ([]*models.User, error)
 	MyUser(ctx context.Context) (*models.User, error)
-	MyAlbums(ctx context.Context, filter *models.Filter, onlyRoot *bool, showEmpty *bool) ([]*models.Album, error)
+	MyAlbums(ctx context.Context, filter *models.Filter, onlyRoot *bool, showEmpty *bool, onlyWithFavorites *bool) ([]*models.Album, error)
 	Album(ctx context.Context, id int) (*models.Album, error)
 	MyMedia(ctx context.Context, filter *models.Filter) ([]*models.Media, error)
 	Media(ctx context.Context, id int) (*models.Media, error)
@@ -304,7 +304,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Album.Media(childComplexity, args["filter"].(*models.Filter)), true
+		return e.complexity.Album.Media(childComplexity, args["filter"].(*models.Filter), args["onlyFavorites"].(*bool)), true
 
 	case "Album.owner":
 		if e.complexity.Album.Owner == nil {
@@ -846,7 +846,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.MyAlbums(childComplexity, args["filter"].(*models.Filter), args["onlyRoot"].(*bool), args["showEmpty"].(*bool)), true
+		return e.complexity.Query.MyAlbums(childComplexity, args["filter"].(*models.Filter), args["onlyRoot"].(*bool), args["showEmpty"].(*bool), args["onlyWithFavorites"].(*bool)), true
 
 	case "Query.myMedia":
 		if e.complexity.Query.MyMedia == nil {
@@ -1244,6 +1244,8 @@ type Query {
     onlyRoot: Boolean
     "Return also albums with no media directly in them"
     showEmpty: Boolean
+    "Show only albums having favorites"
+    onlyWithFavorites: Boolean
   ): [Album!]!
   "Get album by id, user must own the album or be admin"
   album(id: Int!): Album!
@@ -1381,7 +1383,11 @@ type Album {
   id: Int!
   title: String!
   "The media inside this album"
-  media(filter: Filter): [Media!]!
+  media(
+    filter: Filter,
+    "Return only the favorited media"
+    onlyFavorites: Boolean
+  ): [Media!]!
   "The albums contained in this album"
   subAlbums(filter: Filter): [Album!]!
   "The album witch contains this album"
@@ -1502,6 +1508,14 @@ func (ec *executionContext) field_Album_media_args(ctx context.Context, rawArgs 
 		}
 	}
 	args["filter"] = arg0
+	var arg1 *bool
+	if tmp, ok := rawArgs["onlyFavorites"]; ok {
+		arg1, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["onlyFavorites"] = arg1
 	return args, nil
 }
 
@@ -1900,6 +1914,14 @@ func (ec *executionContext) field_Query_myAlbums_args(ctx context.Context, rawAr
 		}
 	}
 	args["showEmpty"] = arg2
+	var arg3 *bool
+	if tmp, ok := rawArgs["onlyWithFavorites"]; ok {
+		arg3, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["onlyWithFavorites"] = arg3
 	return args, nil
 }
 
@@ -2133,7 +2155,7 @@ func (ec *executionContext) _Album_media(ctx context.Context, field graphql.Coll
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Album().Media(rctx, obj, args["filter"].(*models.Filter))
+		return ec.resolvers.Album().Media(rctx, obj, args["filter"].(*models.Filter), args["onlyFavorites"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4529,7 +4551,7 @@ func (ec *executionContext) _Query_myAlbums(ctx context.Context, field graphql.C
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().MyAlbums(rctx, args["filter"].(*models.Filter), args["onlyRoot"].(*bool), args["showEmpty"].(*bool))
+		return ec.resolvers.Query().MyAlbums(rctx, args["filter"].(*models.Filter), args["onlyRoot"].(*bool), args["showEmpty"].(*bool), args["onlyWithFavorites"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -29,6 +29,8 @@ type Query {
     onlyRoot: Boolean
     "Return also albums with no media directly in them"
     showEmpty: Boolean
+    "Show only albums having favorites"
+    onlyWithFavorites: Boolean
   ): [Album!]!
   "Get album by id, user must own the album or be admin"
   album(id: Int!): Album!
@@ -166,7 +168,11 @@ type Album {
   id: Int!
   title: String!
   "The media inside this album"
-  media(filter: Filter): [Media!]!
+  media(
+    filter: Filter,
+    "Return only the favorited media"
+    onlyFavorites: Boolean
+  ): [Media!]!
   "The albums contained in this album"
   subAlbums(filter: Filter): [Album!]!
   "The album witch contains this album"

--- a/ui/src/Pages/AlbumPage/AlbumPage.js
+++ b/ui/src/Pages/AlbumPage/AlbumPage.js
@@ -3,6 +3,7 @@ import ReactRouterPropTypes from 'react-router-prop-types'
 import gql from 'graphql-tag'
 import { Query } from 'react-apollo'
 import AlbumGallery from '../../components/albumGallery/AlbumGallery'
+import PropTypes from 'prop-types'
 
 const albumQuery = gql`
   query albumQuery($id: Int!, $onlyFavorites: Boolean) {
@@ -91,10 +92,14 @@ function AlbumPage({ match }) {
   )
 }
 
-console.log(ReactRouterPropTypes)
-
 AlbumPage.propTypes = {
   ...ReactRouterPropTypes,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string,
+      subPage: PropTypes.string,
+    }),
+  }),
 }
 
 export default AlbumPage

--- a/ui/src/Routes.js
+++ b/ui/src/Routes.js
@@ -41,8 +41,8 @@ class Routes extends React.Component {
           <Route path="/initialSetup" component={InitialSetupPage} />
           <Route path="/share" component={SharePage} />
           <AuthorizedRoute exact path="/albums" component={AlbumsPage} />
-          <AuthorizedRoute path="/album/:id" component={AlbumPage} />
-          <AuthorizedRoute path="/photos" component={PhotosPage} />
+          <AuthorizedRoute path="/album/:id/:subPage?" component={AlbumPage} />
+          <AuthorizedRoute path="/photos/:subPage?" component={PhotosPage} />
           <AuthorizedRoute admin path="/settings" component={SettingsPage} />
           <Route path="/" exact render={() => <Redirect to="/photos" />} />
           <Route render={() => <div>Page not found</div>} />

--- a/ui/src/components/AlbumTitle.js
+++ b/ui/src/components/AlbumTitle.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext } from 'react'
 import PropTypes from 'prop-types'
-import { Breadcrumb } from 'semantic-ui-react'
+import { Breadcrumb, Checkbox } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { Icon } from 'semantic-ui-react'
@@ -33,6 +33,12 @@ const StyledIcon = styled(Icon)`
   }
 `
 
+const FavoritesCheckbox = styled(Checkbox)`
+  float: right;
+  padding-left: 10px;
+  margin-top: 0.5rem;
+`
+
 const SettingsIcon = props => {
   return <StyledIcon name="settings" size="small" {...props} />
 }
@@ -49,7 +55,13 @@ const ALBUM_PATH_QUERY = gql`
   }
 `
 
-const AlbumTitle = ({ album, disableLink = false }) => {
+const AlbumTitle = ({
+  album,
+  disableLink = false,
+  showFavoritesToggle,
+  setOnlyFavorites,
+  onlyFavorites = false,
+}) => {
   const [fetchPath, { data: pathData }] = useLazyQuery(ALBUM_PATH_QUERY)
   const { updateSidebar } = useContext(SidebarContext)
 
@@ -101,6 +113,15 @@ const AlbumTitle = ({ album, disableLink = false }) => {
           }}
         />
       )}
+      {authToken() && showFavoritesToggle && (
+        <FavoritesCheckbox
+          toggle
+          label="Show only the favorites"
+          checked={onlyFavorites}
+          onClick={e => e.stopPropagation()}
+          onChange={() => setOnlyFavorites(!onlyFavorites)}
+        />
+      )}
     </Header>
   )
 }
@@ -108,6 +129,9 @@ const AlbumTitle = ({ album, disableLink = false }) => {
 AlbumTitle.propTypes = {
   album: PropTypes.object,
   disableLink: PropTypes.bool,
+  showFavoritesToggle: PropTypes.bool,
+  setOnlyFavorites: PropTypes.func,
+  onlyFavorites: PropTypes.bool,
 }
 
 export default AlbumTitle

--- a/ui/src/components/albumGallery/AlbumGallery.js
+++ b/ui/src/components/albumGallery/AlbumGallery.js
@@ -5,7 +5,14 @@ import AlbumTitle from '../AlbumTitle'
 import PhotoGallery from '../photoGallery/PhotoGallery'
 import AlbumBoxes from './AlbumBoxes'
 
-const AlbumGallery = ({ album, loading = false, customAlbumLink }) => {
+const AlbumGallery = ({
+  album,
+  loading = false,
+  customAlbumLink,
+  showFavoritesToggle = false,
+  setOnlyFavorites,
+  onlyFavorites = false,
+}) => {
   const [imageState, setImageState] = useState({
     activeImage: -1,
     presenting: false,
@@ -78,7 +85,13 @@ const AlbumGallery = ({ album, loading = false, customAlbumLink }) => {
 
   return (
     <Layout title={album ? album.title : 'Loading album'}>
-      <AlbumTitle album={album} disableLink />
+      <AlbumTitle
+        album={album}
+        disableLink
+        showFavoritesToggle={showFavoritesToggle}
+        onlyFavorites={onlyFavorites}
+        setOnlyFavorites={setOnlyFavorites}
+      />
       {subAlbumElement}
       {
         <h2
@@ -110,6 +123,9 @@ AlbumGallery.propTypes = {
   album: PropTypes.object,
   loading: PropTypes.bool,
   customAlbumLink: PropTypes.func,
+  showFavoritesToggle: PropTypes.bool,
+  setOnlyFavorites: PropTypes.func,
+  onlyFavorites: PropTypes.bool,
 }
 
 export default AlbumGallery

--- a/ui/src/components/photoGallery/PhotoGallery.js
+++ b/ui/src/components/photoGallery/PhotoGallery.js
@@ -6,6 +6,7 @@ import PresentView from './presentView/PresentView'
 import PropTypes from 'prop-types'
 import { SidebarContext } from '../sidebar/Sidebar'
 import MediaSidebar from '../sidebar/MediaSidebar'
+import { forceVisible } from 'react-lazyload'
 
 const Gallery = styled.div`
   display: flex;
@@ -19,6 +20,10 @@ const Gallery = styled.div`
 const PhotoFiller = styled.div`
   height: 200px;
   flex-grow: 999999;
+`
+
+const ClearWrap = styled.div`
+  clear: both;
 `
 
 const PhotoGallery = ({
@@ -100,8 +105,12 @@ const PhotoGallery = ({
     return photoElements
   }
 
+  useEffect(() => {
+    !loading && forceVisible()
+  }, [loading])
+
   return (
-    <div>
+    <ClearWrap>
       <Gallery>
         <Loader active={loading}>Loading images</Loader>
         {getPhotoElements(updateSidebar)}
@@ -113,7 +122,7 @@ const PhotoGallery = ({
           {...{ nextImage, previousImage, setPresenting }}
         />
       )}
-    </div>
+    </ClearWrap>
   )
 }
 


### PR DESCRIPTION
I have added a "Show only the favorites" checkbox on both /pages and /album/:id/ pages
- On Photos page, when the toggle is checked only albums containing favorited media are displayed and only favorited media is lisred. The URL changes to /photos/favorites and it can be used to directly access the favorited media.
- On the individual album's page, the toggle shows only favorited media when it is checked. The URL changes to /album/ID/favorites and it can be used to directly access the favorited media from this particular album.
- forceVisible() is called when the loading ends in PhotoGallery component because otherwise if you switch to Favorites and some of the favorited images have been outside the viewport before that, they will not be lazy-loaded once they are "moved" to the visible area because non-favorited images are cleared. 
