### PR TITLE
Replace buildx action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             ${TAGS} --file Dockerfile .
 
       - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
 
       - name: Docker Buildx (build)
         run: |


### PR DESCRIPTION
Replace `crazy-max/ghaction-docker-buildx@v3` with `docker/setup-buildx-action@v1`, since the old version has been archived and moved to the new one.

See
https://github.com/crazy-max/ghaction-docker-buildx